### PR TITLE
Define scalar variables rather than arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin can be used to trigger automatic payments for specific subscriptions
 ### Example Usage
 
 ```
-define( 'WCS_UPSTAGED_SUBSCRIPTION_IDS', array( 123, 5813, 2134 ) );
+define( 'WCS_UPSTAGED_SUBSCRIPTION_IDS', json_encode( array( 123, 5813, 2134 ) ) );
 ```
 
 ### Suggested Usage

--- a/wcs-upstage.php
+++ b/wcs-upstage.php
@@ -29,7 +29,7 @@
 
 function wcs_upstage( $subscription_id ) {
 
-	if ( ! WC_Subscriptions::is_duplicate_site() || ! defined( 'WCS_UPSTAGED_SUBSCRIPTION_IDS' ) || ! is_array( WCS_UPSTAGED_SUBSCRIPTION_IDS ) || ! in_array( $subscription_id, WCS_UPSTAGED_SUBSCRIPTION_IDS ) ) {
+	if ( ! WC_Subscriptions::is_duplicate_site() || ! defined( 'WCS_UPSTAGED_SUBSCRIPTION_IDS' ) || ! is_array( $subscription_ids = json_decode( WCS_UPSTAGED_SUBSCRIPTION_IDS ) ) || ! in_array( $subscription_id, $subscription_ids ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Defining the `WCS_UPSTAGED_SUBSCRIPTION_IDS` constant as an array would cause the following error:

```
PHP Warning:  Constants may only evaluate to scalar values in
```

This patch updates the README and the `wcs_upstage()` function to take json encoded `WCS_UPSTAGED_SUBSCRIPTION_IDS` constants.

eg 

```php 
define( 'WCS_UPSTAGED_SUBSCRIPTION_IDS', json_encode( array( 123, 5813, 2134 ) ) );
```