### PR TITLE
Update wcs-upstage.php

### DIFF
--- a/wcs-upstage.php
+++ b/wcs-upstage.php
@@ -33,7 +33,7 @@
 
 function wcs_upstage( $subscription_id ) {
 
-	if ( ! WC_Subscriptions::is_duplicate_site() || ! defined( 'WCS_UPSTAGED_SUBSCRIPTION_IDS' ) || ! is_array( $subscription_ids = json_decode( WCS_UPSTAGED_SUBSCRIPTION_IDS ) ) || ! in_array( $subscription_id, $subscription_ids ) ) {
+	if ( ! WCS_Staging::is_duplicate_site() || ! defined( 'WCS_UPSTAGED_SUBSCRIPTION_IDS' ) || ! is_array( $subscription_ids = json_decode( WCS_UPSTAGED_SUBSCRIPTION_IDS ) ) || ! in_array( $subscription_id, $subscription_ids ) ) {
 		return;
 	}
 


### PR DESCRIPTION
`WC_Subscriptions::is_duplicate_site()` has been deprecated and no longer in use, so this plugin does not work. 

This updates that class to: `WCS_Staging::is_duplicate_site()` – in the `if` statement, that way the condition will pass.